### PR TITLE
fix: Jekyll 3.x互換のタグソート修正

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -141,7 +141,7 @@ layout: default
   <div class="tag-cloud-section">
     <h2>🏷 人気タグ</h2>
     <div class="tag-cloud">
-      {%- assign sorted_tags = site.tags | sort: 1 | reverse -%}
+      {%- assign sorted_tags = site.tags | sort -%}
       {%- for tag in sorted_tags limit:25 -%}
       <span>{{ tag[0] }}<span class="tag-count">({{ tag[1].size }})</span></span>
       {%- endfor -%}


### PR DESCRIPTION
sort: 1 が Jekyll 3.x でエラーになるためアルファベット順ソートに変更。limit:25 は維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)